### PR TITLE
liblogging-1.0.2 should also check for rst2man.py

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,8 +127,8 @@ AC_ARG_ENABLE(cached_man_pages,
 )
 if test "x$enable_cached_man_pages" = "xno"; then
 # obtain path for rst2man
-    AC_PATH_PROG([RST2MAN], [rst2man])
-    if test "x${RST2MAN}" == "x"; then
+    AC_PATH_PROGS([RST2MAN], [rst2man rst2man.py], "no")
+    if test "x${RST2MAN}" == "xno"; then
         AC_MSG_FAILURE([rst2man not found in PATH])
     fi
 fi


### PR DESCRIPTION
Hi,

the current liblogging-1.0.2 configure script only checks for `rst2man`. But if you install the Python docutils packages via PiP or from PyPi you will end with `/usr/bin/rst2man.py` instead of `/usr/bin/rst2man` so you should support both.

PS: That you are now using rst2man (docutils dependency; yes optional - you could use the cached version) is something I would have mentioned in the changelogs, too.
