### PR TITLE
Remove "--enable-cached-man-pages" switch and make rst2man optional when man pages already exist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,22 +114,23 @@ if test "$enable_journal" = "yes"; then
         AC_DEFINE(ENABLE_JOURNAL, 1, [journal support is integrated.])
 fi
 
-# Support using cached man file copies, to avoid the need for rst2man
-# in the build environment
-AC_ARG_ENABLE(cached_man_pages,
-        [AS_HELP_STRING([--enable-cached-man-pages],[Enable using cached versions of man files (avoid rst2man) @<:@default=no@:>@])],
-        [case "${enableval}" in
-         yes) enable_cached_man_pages="yes" ;;
-          no) enable_cached_man_pages="no" ;;
-           *) AC_MSG_ERROR(bad value ${enableval} for --enable-cached-man-pages) ;;
-         esac],
-        [enable_cached_man_pages=no]
+AC_CHECKING([if all man pages already exist])
+have_to_generate_man_pages="no"
+AC_CHECK_FILES(["stdlog/stdlog.3" "stdlog/stdlogctl.1"],
+    [],
+    [have_to_generate_man_pages="yes"]
 )
-if test "x$enable_cached_man_pages" = "xno"; then
-# obtain path for rst2man
-    AC_PATH_PROGS([RST2MAN], [rst2man rst2man.py], "no")
-    if test "x${RST2MAN}" == "xno"; then
-        AC_MSG_FAILURE([rst2man not found in PATH])
+if test "x$have_to_generate_man_pages" = "xyes"; then
+    AC_MSG_RESULT([Some man pages are missing. We need rst2man to generate the missing man pages from source...])
+else
+    AC_MSG_RESULT([All man pages found. We don't need rst2man!])
+fi
+
+if test "x$have_to_generate_man_pages" = "xyes"; then
+    # We need rst2man to generate our man pages
+    AC_CHECK_PROGS([RST2MAN], [rst2man rst2man.py], [])
+    if test -z "$RST2MAN"; then
+        AC_MSG_ERROR([rst2man is required to build man pages. You can use the release tarball with pregenerated man pages to avoid this depedency.])
     fi
 fi
 
@@ -148,4 +149,5 @@ echo
 echo "stdlog support enabled:               $enable_stdlog"
 echo "systemd journal support:              $enable_journal"
 echo "rfc3195 support enabled:              $enable_rfc3195"
-echo "using cached copies of man files:     $enable_cached_man_pages"
+echo "have to generate man pages:           $have_to_generate_man_pages"
+echo "********************************************************"


### PR DESCRIPTION
liblogging-1.0.2 introduced a new "--enable-cached-man-pages" switch to
allow building the package without the need for rst2man from docutils.

This was a problem, because this was only working with the "special"
release tarball containing pregenerated man pages.
When building from source or after you cleaned the source from the release
tarball, you experienced the following error when you used the
"--enable-cached-man-pages" switch:

```
stdlogctl.rst: Command not found
```

This was because we didn't check for rst2man when the switch was used and
therefore $RST2MAN was undefined when the Makefile tried to build the man
page target which failed.

This patch will remove the switch. Therefore we are now checking if
every man page already exists or not. If a man page is missing we'll check
for rst2man because it is still used in the Makefile (if every man page
exists, make doesn't have to build the target and therefore won't use
the still undefined $RST2MAN variable).

Fixes #13
