### PR TITLE
Fix man page detection when cross compiling.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,10 +127,9 @@ AC_ARG_ENABLE(man-pages,
 if test "x$enable_man_pages" = "xyes"; then
 	AC_CHECKING([if all man pages already exist])
 	have_to_generate_man_pages="no"
-	AC_CHECK_FILES(["stdlog/stdlog.3" "stdlog/stdlogctl.1"],
-	    [],
-	    [have_to_generate_man_pages="yes"]
-	)
+	if test ! -r "stdlog/stdlog.3" || test ! -r "stdlog/stdlogctl.1"; then
+		have_to_generate_man_pages="yes"
+	fi
 	if test "x$have_to_generate_man_pages" = "xyes"; then
 	    AC_MSG_RESULT([Some man pages are missing. We need rst2man to generate the missing man pages from source... Alternatively, use --disable-man-pages to build without them.])
 	else


### PR DESCRIPTION
AC_CHECK_FILE(S) is meant for checks of files on the native system and does
not work when cross compiling (see [lib/autoconf/general.m4](http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=blob;f=lib/autoconf/general.m4;h=59d204f6a3c7a3b24b6af796e8ec179a4f6c93e0;hb=HEAD#l2832)).
