### PR TITLE
Issue-32: stdlog should support functionality like the syslog LOG_PID…

### DIFF
--- a/stdlog/file.c
+++ b/stdlog/file.c
@@ -53,6 +53,11 @@ build_file_line(stdlog_channel_t ch,
 	i += __stdlog_formatTimestamp3164(&tm, linebuf+i);
 	__STDLOG_STRBUILD_ADD_CHAR(linebuf, lenline, i, ' ');
 	__stdlog_fmt_print_str(linebuf, lenline-i, &i, ch->ident);
+	if (ch->options & STDLOG_PID) {
+		__STDLOG_STRBUILD_ADD_CHAR(linebuf, lenline, i, '[');
+		__stdlog_fmt_print_int(linebuf, lenline, &i, getpid());
+		__STDLOG_STRBUILD_ADD_CHAR(linebuf, lenline, i, ']');
+	}
 	__STDLOG_STRBUILD_ADD_CHAR(linebuf, lenline, i, ':');
 	__STDLOG_STRBUILD_ADD_CHAR(linebuf, lenline, i, ' ');
 	/* note: we do not need to reserve space for '\0', as we

--- a/stdlog/stdlog.h
+++ b/stdlog/stdlog.h
@@ -33,6 +33,7 @@
 
 /* options for stdlog_open() call */
 #define STDLOG_SIGSAFE 1	/* enforce signal-safe implementation */
+#define STDLOG_PID     2	/* log the PID with each message */
 #define STDLOG_USE_DFLT_OPTS ((int)0x80000000)	/* use default options */
 
 /* traditional syslog facility codes */

--- a/stdlog/stdlog.rst
+++ b/stdlog/stdlog.rst
@@ -151,6 +151,9 @@ The following options can be given:
    specified library calls are signal-safe. Some restrictions apply
    in signal-safe mode. See description below for details.
 
+:STDLOG_PID: log the process identifier (PID) of the originator with each
+   message.
+
 FACILITIES
 ==========
 The following facilities are supported. Please note that they are mimicked

--- a/stdlog/tester.c
+++ b/stdlog/tester.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "stdlog.h"
 
 int main(int argc, char *argv[])
@@ -7,14 +8,24 @@ int main(int argc, char *argv[])
 	char buf[40];
 	stdlog_channel_t ch;
 	stdlog_channel_t ch2;
-	if(argc != 2) {
-		fprintf(stderr, "Usage: tester channelspec\n");
+	int dflt_option = STDLOG_SIGSAFE;
+	int option = 0;
+	char *chanspec = NULL;
+
+	if (3 == argc && (0 == strcmp(argv[1], "-p"))) {
+		dflt_option |= STDLOG_PID;
+		option |= STDLOG_PID;
+		chanspec = argv[2];
+	} else if (2 == argc) {
+		chanspec = argv[1];
+	} else if(argc < 2 || argc > 3) {
+		fprintf(stderr, "Usage: tester [-p] channelspec\n");
 		exit(1);
 	}
 
-	stdlog_init(STDLOG_SIGSAFE);
-	ch = stdlog_open("tester", 0, STDLOG_LOCAL0, argv[1]);
-	ch2 = stdlog_open("tester", STDLOG_USE_DFLT_OPTS, STDLOG_LOCAL0, argv[1]);
+	stdlog_init(dflt_option);
+	ch = stdlog_open("tester", option, STDLOG_LOCAL0, chanspec);
+	ch2 = stdlog_open("tester", STDLOG_USE_DFLT_OPTS, STDLOG_LOCAL0, chanspec);
 	stdlog_log(ch, STDLOG_DEBUG, "Test %10.6s, %u, %d, %c, %x, %p, %f",
 		   "abc", 4712, -4712, 'T', 0x129abcf0, NULL, 12.0345);
 	stdlog_log_b(ch2, STDLOG_DEBUG, buf, sizeof(buf), "Test %100.50s, %u, %d, %c, %x, %p, %f",

--- a/stdlog/uxsock.c
+++ b/stdlog/uxsock.c
@@ -61,6 +61,11 @@ build_syslog_frame(stdlog_channel_t ch,
 	i += __stdlog_formatTimestamp3164(&tm, frame+i);
 	__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, ' ');
 	__stdlog_fmt_print_str(frame, lenframe-i, &i, ch->ident);
+	if (ch->options & STDLOG_PID) {
+		__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, '[');
+		__stdlog_fmt_print_int(frame, lenframe, &i, getpid());
+		__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, ']');
+	}
 	__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, ':');
 	__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, ' ');
 	i += ch->f_vsnprintf(frame+i, lenframe-i, fmt, ap);


### PR DESCRIPTION
… option

Implement a STDLOG_PID option to specify that each log message should be tagged
with the process identifier as well as the ident. This is done in the format
"ident[pid]" as described in RFC-3164. This is honored by both the file: and
uxsock: channel drivers.

Update the test program to allow use of the STDLOG_PID option.
