### PR TITLE
Issue-33: build_file_line and build_syslog_frame call the __stdlog_pr…

### DIFF
--- a/stdlog/file.c
+++ b/stdlog/file.c
@@ -52,7 +52,7 @@ build_file_line(stdlog_channel_t ch,
 	__stdlog_timesub(&t, 0, &tm);
 	i += __stdlog_formatTimestamp3164(&tm, linebuf+i);
 	__STDLOG_STRBUILD_ADD_CHAR(linebuf, lenline, i, ' ');
-	__stdlog_fmt_print_str(linebuf, lenline-i, &i, ch->ident);
+	__stdlog_fmt_print_str(linebuf, lenline, &i, ch->ident);
 	if (ch->options & STDLOG_PID) {
 		__STDLOG_STRBUILD_ADD_CHAR(linebuf, lenline, i, '[');
 		__stdlog_fmt_print_int(linebuf, lenline, &i, getpid());

--- a/stdlog/uxsock.c
+++ b/stdlog/uxsock.c
@@ -56,11 +56,11 @@ build_syslog_frame(stdlog_channel_t ch,
 	pri = (ch->facility << 3) | (severity & 0x07);
 	__stdlog_timesub(&t, 0, &tm);
 	__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, '<');
-	__stdlog_fmt_print_int(frame, lenframe-i, &i, pri); 
+	__stdlog_fmt_print_int(frame, lenframe, &i, pri);
 	__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, '>');
 	i += __stdlog_formatTimestamp3164(&tm, frame+i);
 	__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, ' ');
-	__stdlog_fmt_print_str(frame, lenframe-i, &i, ch->ident);
+	__stdlog_fmt_print_str(frame, lenframe, &i, ch->ident);
 	if (ch->options & STDLOG_PID) {
 		__STDLOG_STRBUILD_ADD_CHAR(frame, lenframe, i, '[');
 		__stdlog_fmt_print_int(frame, lenframe, &i, getpid());


### PR DESCRIPTION
…int_\* functions incorrectly

Change these functions so that they call the __stdlog_print_\* functions with
the correct buffer size.
