### PR TITLE
bugfix: build on freebsd

### DIFF
--- a/stdlog/Makefile.am
+++ b/stdlog/Makefile.am
@@ -53,8 +53,8 @@ CLEANFILES += stdlog.3
 EXTRA_DIST += stdlog.3
 
 stdlogctl.1: stdlogctl.rst
-	$(AM_V_GEN) $(RST2MAN) $< $@
+	$(AM_V_GEN) $(RST2MAN) stdlogctl.rst $@
 
 stdlog.3: stdlog.rst
-	$(AM_V_GEN) $(RST2MAN) $< $@
+	$(AM_V_GEN) $(RST2MAN) stdlog.rst $@
 endif


### PR DESCRIPTION
as it looks, freebsd does not understand the $< make auto variable
So we replace it with the actual file name. That is a bit unelegant,
but works... ;-)