### PR TITLE
fix small memory leaks in libstdlog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 ----------------------------------------------------------------------------
 v1.0.6 2015-??-??
+- fix small memory leaks in libstdlog
+  each open/close leaked a couple of bytes; this was no problem, except if
+  they were called very often. However, it was a problem when using memory
+  debuggers, which rightfully complained.
 - fix BSD build
 - enhancement:  sigsafe_printf now recognizes the "j" length modifier
   Thanks to David A. Bright for implementing this

--- a/stdlog/stdlog.c
+++ b/stdlog/stdlog.c
@@ -174,6 +174,8 @@ done:
 void
 stdlog_close(stdlog_channel_t ch)
 {
+	free((void*)ch->spec);
+	free((void*)ch->ident);
 	ch->drvr.close(ch);
 	free(ch);
 }

--- a/stdlog/uxsock.c
+++ b/stdlog/uxsock.c
@@ -1,7 +1,7 @@
 /* The stdlog unix socket driver. Syslog protocol is spoken on
  * all unix sockets.
  *
- * Copyright (C) 2014 Adiscon GmbH
+ * Copyright (C) 2014-2017 Adiscon GmbH
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -103,10 +103,13 @@ static void
 uxs_close(stdlog_channel_t ch)
 {
 	if (ch->d.uxs.sock >= 0) {
-		free(ch->d.uxs.sockname);
 		close(ch->d.uxs.sock);
 		ch->d.uxs.sock = -1;
 	}
+	/* we need to free buffers no matter if the socket was ever
+	 * opened or not.
+	 */
+	free(ch->d.uxs.sockname);
 }
 
 


### PR DESCRIPTION
each open/close leaked a couple of bytes; this was no problem, except if
they were called very often. However, it was a problem when using memory
debuggers, which rightfully complained.